### PR TITLE
Cast property name as string to allow for "1" property names

### DIFF
--- a/src/Data/Value/DecodedJson/NodeObjectValue.php
+++ b/src/Data/Value/DecodedJson/NodeObjectValue.php
@@ -37,6 +37,7 @@ final class NodeObjectValue implements NodeValueInterface, ObjectValueInterface
     private function createChildGenerator(): Generator
     {
         foreach (get_object_vars($this->data) as $name => $property) {
+            $name = (string) $name;
             yield $name => $this
                 ->valueFactory
                 ->createValue($property, $this->path->copyWithProperty($name));


### PR DESCRIPTION
This pull request addresses an issue with using "numeric" property names in the json.

Allowed in PHP:
```php
$json = '{ "1": "value" }';
$o = json_decode($json);
print_r($o->{'1'});
```
Fixes fatal error
```
Fatal error: Uncaught TypeError: Argument 1 passed to Remorhaz\JSON\Data\Path\Path::copyWithProperty() must be of the type string, int given, called in /app/vendor/remorhaz/php-json-path/src/Data/Value/DecodedJson/NodeObjectValue.php on line 38 and defined in /app/vendor/remorhaz/php-json-path/src/Query/Query.php on line 45
```
